### PR TITLE
修复更新图标材质不能为 AIR 的 BUG

### DIFF
--- a/src/main/kotlin/me/arasple/mc/trmenu/api/menu/IItem.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/api/menu/IItem.kt
@@ -20,9 +20,10 @@ interface IItem {
     fun generate(session: MenuSession, texture: Texture, name: String?, lore: List<String>?, meta: Meta): ItemStack {
         val item = texture.generate(session)
         val builder = ItemBuilder(item)
-
-        name?.let { builder.name(it) }
-        lore?.let { builder.lore(it) }
+        if (item.itemMeta != null) {
+            name?.let { builder.name(it) }
+            lore?.let { builder.lore(it) }
+        }
         meta.flags(builder)
         meta.shiny(session, builder)
 

--- a/src/main/kotlin/me/arasple/mc/trmenu/api/receptacle/ReceptacleAPI.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/api/receptacle/ReceptacleAPI.kt
@@ -71,6 +71,7 @@ object ReceptacleAPI {
             // 防止关闭菜单后, 动态标题频率过快出现的卡假容器
             Tasks.delay(async = true) {
                 MANAGER.getViewingReceptacle(player) ?: kotlin.run { PacketWindowClose().send(player) }
+                player.updateInventory()
             }
 
             return false

--- a/src/main/kotlin/me/arasple/mc/trmenu/module/display/item/Item.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/module/display/item/Item.kt
@@ -45,6 +45,8 @@ class Item(
 
         if (!cache.containsKey(session.id))
             build(session)
+        else if (cache[session.id]!!.itemMeta == null)
+            build(session)
         else
             cache[session.id]!!.itemMeta?.let {
                 build(session, it.displayName, it.lore ?: listOf())

--- a/src/main/kotlin/me/arasple/mc/trmenu/util/bukkit/ItemMatcher.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/util/bukkit/ItemMatcher.kt
@@ -113,7 +113,7 @@ class ItemMatcher(private val matcher: Set<Match>) {
             val name = getTrait(NAME)
             val nameMatch = name == null || itemStack.itemMeta?.displayName?.contains(name, true) == true
 
-            val lore = getTrait(NAME)
+            val lore = getTrait(LORE)
             val loreMatch = lore == null || itemStack.itemMeta?.lore?.any { it.contains(lore, true) } ?: false
 
             val head = getTrait(HEAD)


### PR DESCRIPTION
（不太会写kotlin，大佬看看有没有更优写法）
- 所有没有 itemMeta 的材质都会报空指针

 ``` yaml
 '*':
    update: 10
    display:
      mats:
        - AIR
        - SLIME_STAINED_GLASS_PANE
      name: '&f'