### PR TITLE
Support FastScript.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ repositories {
     mavenCentral()
     maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
     maven { url 'https://repo.codemc.org/repository/maven-public' }
+    maven { url 'http://repo.iroselle.com/snapshots/' }
 }
 
 dependencies {
@@ -42,6 +43,8 @@ dependencies {
     compile 'me.clip:placeholderapi:2.10.9'
     compile 'org.bstats:bstats-bukkit:1.8'
     compile 'net.wesjd:anvilgui:1.4.0-SNAPSHOT'
+    compileOnly 'me.scoretwo:FastScript-common:1.0.2-SNAPSHOT'
+    compileOnly 'me.scoretwo:commons-bukkit-plugin:2.0.11-SNAPSHOT'
     compileOnly fileTree(dir: 'libs', includes: ['*.jar'])
 }
 

--- a/src/main/kotlin/me/arasple/mc/trmenu/module/internal/hook/HookPlugin.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/module/internal/hook/HookPlugin.kt
@@ -15,7 +15,8 @@ object HookPlugin {
         HookSkinsRestorer(),
         HookItemsAdder(),
         HookFloodgate(),
-        HookVault()
+        HookVault(),
+        HookFastScript()
     )
 
     fun getHeadDatabase(): HookHeadDatabase {
@@ -44,6 +45,10 @@ object HookPlugin {
 
     fun getVault(): HookVault {
         return registry[6] as HookVault
+    }
+
+    fun getFastScript(): HookFastScript {
+        return registry[7] as HookFastScript
     }
 
 }

--- a/src/main/kotlin/me/arasple/mc/trmenu/module/internal/hook/impl/HookFastScript.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/module/internal/hook/impl/HookFastScript.kt
@@ -1,0 +1,16 @@
+package me.arasple.mc.trmenu.module.internal.hook.impl
+
+import me.arasple.mc.trmenu.module.internal.hook.HookAbstract
+import me.scoretwo.fastscript.FastScript
+
+/**
+ * @author Score2
+ * @date 2021/2/24 22:02
+ */
+class HookFastScript : HookAbstract() {
+
+    val expansionManager get() = FastScript.instance.expansionManager
+
+    fun getExpansionByNameOrSign(key: String) = expansionManager.getExpansionBySign(key) ?: expansionManager.getExpansionByName(key)
+
+}

--- a/src/main/kotlin/me/arasple/mc/trmenu/module/internal/script/FunctionParser.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/module/internal/script/FunctionParser.kt
@@ -4,10 +4,12 @@ import io.izzel.taboolib.kotlin.Indexed
 import me.arasple.mc.trmenu.api.TrMenuAPI
 import me.arasple.mc.trmenu.module.display.MenuSession
 import me.arasple.mc.trmenu.module.internal.data.Metadata
+import me.arasple.mc.trmenu.module.internal.hook.HookPlugin
 import me.arasple.mc.trmenu.module.internal.script.js.JavaScriptAgent
 import me.arasple.mc.trmenu.util.Regexs
 import me.arasple.mc.trmenu.util.collections.Variables
 import me.arasple.mc.trmenu.util.print
+import me.scoretwo.utils.bukkit.command.toGlobalPlayer
 import org.bukkit.entity.Player
 
 /**
@@ -30,13 +32,31 @@ object FunctionParser {
                     if (split.size < 2) return@joinToString it.value
                     val value = split[1]
 
-                    when (split[0].toLowerCase()) {
+                    when (val action = split[0].toLowerCase()) {
                         "kether", "ke" -> parseKetherFunction(player, value)
                         "javascript", "js" -> parseJavaScript(session, value)
                         "meta" -> Metadata.getMeta(player)[value].toString()
                         "data" -> Metadata.getData(player)[value].toString()
                         "globaldata", "gdata" -> Metadata.globalData.get(value).toString()
-                        else -> "___ UNKNOWN $split ___"
+                        else -> {
+                            // - FastScript -
+                            let {
+                                if (!HookPlugin.getFastScript().isHooked) return@let
+                                val expansion = HookPlugin.getFastScript().getExpansionByNameOrSign(action) ?: return@let
+                                return@joinToString try {
+                                    expansion.eval(
+                                        value,
+                                        player.toGlobalPlayer(),
+                                        arrayOf(),
+                                        mutableMapOf("session" to session)
+                                    ).toString()
+                                } catch (t: Throwable) {
+                                    "___ FASTSCRIPT ERROR $split ___"
+                                }
+                            }
+
+                            "___ UNKNOWN $split ___"
+                        }
                     }
                 } else it.value
             }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -25,6 +25,7 @@ softdepend:
   - SkinsRestorer
   - ItemsAdder
   - floodgate-bukkit
+  - FastScript
 
 built-time: ${built}
 built-by: ${builder}


### PR DESCRIPTION
What is FastScript: [GITHUB](https://github.com/FastScriptModule/FastScript) or [MCBBS](https://www.mcbbs.net/thread-1175563-1-1.html)

Use FastScript's expansion to make TrMenu support scripts with more engines, such as Groovy, KotlinScript, and Scala scripts.

Currently I only support the "函数变量" part, and I can't do anything about the "内置脚本函数" part because I can't directly determine the script type.