### PR TITLE
Edit item action

### DIFF
--- a/src/main/kotlin/me/arasple/mc/trmenu/api/action/Actions.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/api/action/Actions.kt
@@ -63,6 +63,7 @@ object Actions {
         ActionPointsAdd.registery,
         ActionPointsTake.registery,
         // Item
+        ActionEditItem.registery,
         ActionEnchantItem.registery,
         ActionTakeItem.registery,
         ActionRepairItem.registery,

--- a/src/main/kotlin/me/arasple/mc/trmenu/api/action/impl/func/ActionEditItem.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/api/action/impl/func/ActionEditItem.kt
@@ -1,0 +1,158 @@
+package me.arasple.mc.trmenu.api.action.impl.func
+
+import me.arasple.mc.trmenu.api.action.base.AbstractAction
+import me.arasple.mc.trmenu.api.action.base.ActionOption
+import me.arasple.mc.trmenu.util.Regexs
+import me.arasple.mc.trmenu.util.bukkit.ItemHelper
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemFlag
+import org.bukkit.inventory.ItemStack
+import taboolib.common.util.replaceWithOrder
+import taboolib.library.xseries.XMaterial
+
+/**
+ * @author Rubenicos
+ * @date 2021/11/14 19:45
+ */
+class ActionEditItem(
+    val method: Int,
+    val item: String,
+    val part: Pair<Int, String>,
+    val value: List<String>,
+    option: ActionOption) : AbstractAction(option = option) {
+
+    override fun onExecute(player: Player, placeholderPlayer: Player) {
+        if (method < 1 || item.isBlank() || part.first < 1 || value.isEmpty()) return
+        val item = ItemHelper.fromPlayerInv(player.inventory, this.item) ?: return
+        val value = placeholderPlayer.session().parse(this.value)
+        when (part.first) {
+            1 -> { // Material
+                if (method == 1) {
+                    val material = XMaterial.matchXMaterial(value[0])
+                    if (material.isPresent) {
+                        val mat = material.get().parseMaterial() ?: return
+                        if (item is Array<*>) {
+                            item.forEach { (it as ItemStack?)?.let { item -> material(item, mat) } }
+                        } else if (item is ItemStack) material(item, mat)
+                    }
+                }
+            }
+            2 -> { // Name
+                val name = if (method == 2) null else value.joinToString(" ")
+                if (item is Array<*>) {
+                    item.forEach { (it as ItemStack?)?.let { item -> name(item, name) } }
+                } else if (item is ItemStack) name(item, name)
+            }
+            3 -> { // Lore
+                if (item is Array<*>) {
+                    item.forEach { (it as ItemStack?)?.let { item -> lore(item, value) } }
+                } else if (item is ItemStack) lore(item, value)
+            }
+            4 -> { // Flags
+                val flags: MutableList<ItemFlag> = ArrayList()
+                value.forEach {
+                    try {
+                        flags.add(ItemFlag.valueOf(it))
+                    } catch (ignored: Exception) { }
+                }
+                if (flags.isNotEmpty()) {
+                    if (item is Array<*>) {
+                        item.forEach { (it as ItemStack?)?.let { item -> flags(item, flags) } }
+                    } else if (item is ItemStack) flags(item, flags)
+                }
+            }
+        }
+    }
+
+    private fun material(item: ItemStack, material: Material) {
+        item.type = material
+    }
+
+    private fun name(item: ItemStack, name: String?) {
+        val meta = item.itemMeta?: return
+        if (name == null) {
+            meta.setDisplayName(null)
+        } else {
+            meta.setDisplayName((if (method == 3 && meta.hasDisplayName()) meta.displayName else "") + name)
+        }
+        item.itemMeta = meta
+    }
+
+    private fun lore(item: ItemStack, value: List<String>) {
+        val meta = item.itemMeta?: return
+        var lore = meta.lore?: arrayListOf<String>()
+        if (part.second.isBlank()) {
+            when (method) {
+                1 -> lore = value
+                2 -> lore.clear()
+                3 -> lore.addAll(value)
+            }
+        } else {
+            val index = if (part.second == "last") lore.size - 1 else part.second.toIntOrNull()?: 0
+            if (lore.size >= index) {
+                when (method) {
+                    1 -> lore[index] = value[0]
+                    2 -> lore.removeAt(index)
+                    3 -> lore.addAll(index, value)
+                }
+            } else return
+        }
+        meta.lore = lore
+        item.itemMeta = meta
+    }
+
+    private fun flags(item: ItemStack, flags: List<ItemFlag>) {
+        val meta = item.itemMeta?: return
+        when (method) {
+            1 -> {
+                meta.itemFlags.forEach { meta.removeItemFlags(it) }
+                flags.forEach { meta.addItemFlags(it) }
+            }
+            2 -> flags.forEach { if (meta.hasItemFlag(it)) meta.removeItemFlags(it) }
+            3 -> flags.forEach { if (!meta.hasItemFlag(it)) meta.addItemFlags(it) }
+        }
+        item.itemMeta = meta
+    }
+
+    companion object {
+        private val name = "edit(-)?items?".toRegex()
+
+        private val parser: (Any, ActionOption) -> AbstractAction = { value, option ->
+            val content: String = value.toString()
+            val split = content.split(" ", limit = 4)
+            var rawValue = split.getOrElse(3) { "" }
+
+            val replacements = Regexs.SENTENCE.findAll(rawValue).mapIndexed { index, result ->
+                rawValue = rawValue.replace(result.value, "{$index}")
+                index to result.groupValues[1].replace("\\s", " ")
+            }.toMap().values.toTypedArray()
+
+            val replacedValue: MutableList<String> = ArrayList()
+            rawValue.split(" ").toTypedArray().forEach { s -> replacedValue.add(s.replaceWithOrder(*replacements)) }
+
+            val part = split.getOrElse(2) { "" }.lowercase().split(":", ";", "=", limit = 2)
+            ActionEditItem(
+                when (split.getOrElse(0) { "" }.lowercase()) {
+                    "set", "put" -> 1
+                    "delete", "remove" -> 2
+                    "add", "concat" -> 3
+                    else -> 0
+                },
+                split.getOrElse(1) { "" },
+                when (part.getOrElse(0) { "" }) {
+                    "mat", "material", "type" -> 1
+                    "name", "displayname" -> 2
+                    "lore", "description" -> 3
+                    "flag", "flags" -> 4
+                    else -> 0
+                } to part.getOrElse(1) { "" },
+                replacedValue,
+                option
+            )
+        }
+
+        val registery = name to parser
+
+    }
+}

--- a/src/main/kotlin/me/arasple/mc/trmenu/api/action/impl/func/ActionEnchantItem.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/api/action/impl/func/ActionEnchantItem.kt
@@ -18,18 +18,14 @@ class ActionEnchantItem(content: String, option: ActionOption) : AbstractAction(
 
     override fun onExecute(player: Player, placeholderPlayer: Player) {
         parseContentSplited(placeholderPlayer, ";").forEach {
-            val split = it.split(",", limit = 4).toTypedArray()
+            val split = it.split(",", " ", limit = 4).toTypedArray()
             if (split.size >= 3) {
                 val l = split[2].split("-").toTypedArray()
                 val level = if (l.size > 1) ((l[0].toIntOrNull()?: 0)..(l[1].toIntOrNull()?: 0)).random() else l[0].toIntOrNull()?: 0
                 if (level > 0) {
-                    if (split[1].startsWith("$ ")) {
-                        enchant(ItemHelper.fromPlayerInv(player.inventory, split[0]), split[1].substring(2), level, if (split.size > 3) split[3] else "0")
-                    } else {
-                        val enchant = XEnchantment.matchXEnchantment(split[1])
-                        if (enchant.isPresent) {
-                            enchant(ItemHelper.fromPlayerInv(player.inventory, split[0]), enchant.get().parseEnchantment(), level)
-                        }
+                    val enchant = XEnchantment.matchXEnchantment(split[1])
+                    if (enchant.isPresent) {
+                        enchant(ItemHelper.fromPlayerInv(player.inventory, split[0]), enchant.get().parseEnchantment(), level)
                     }
                 }
             }
@@ -46,44 +42,10 @@ class ActionEnchantItem(content: String, option: ActionOption) : AbstractAction(
 
         val registery = name to parser
 
-        fun enchant(any: Any?, customEnchant: String, level: Int, lineIndex: String = "0") {
-            if (any is Array<*>) {
-                any.forEach { enchantItem(it as ItemStack?, customEnchant, level, lineIndex) }
-            } else if (any is ItemStack) enchantItem(any, customEnchant, level, lineIndex)
-        }
-
         fun enchant(any: Any?, enchant: Enchantment?, level: Int) {
             if (any is Array<*>) {
                 any.forEach { enchantItem(it as ItemStack?, enchant, level) }
             } else if (any is ItemStack) enchantItem(any, enchant, level)
-        }
-
-        fun enchantItem(item: ItemStack?, customEnchant: String, level: Int, lineIndex: String = "0") {
-            if (item != null) {
-                val meta = item.itemMeta!!
-                val line = "$customEnchant " + when(level) {
-                    1 -> "I"
-                    2 -> "II"
-                    3 -> "III"
-                    4 -> "IV"
-                    5 -> "V"
-                    6 -> "VI"
-                    7 -> "VII"
-                    8 -> "VIII"
-                    9 -> "IX"
-                    10 -> "X"
-                    else -> level.toString()
-                }
-                val lore = meta.lore?: arrayListOf<String>()
-                if (lineIndex.equals("last", true)) {
-                    lore.add(line)
-                } else {
-                    val index = lineIndex.toIntOrNull()?: 0
-                    lore.add(if (lore.size >= index) index else 0, line)
-                }
-                meta.lore = lore
-                item.itemMeta = meta
-            }
         }
 
         fun enchantItem(item: ItemStack?, enchant: Enchantment?, level: Int) {

--- a/src/main/kotlin/me/arasple/mc/trmenu/module/internal/script/js/Assist.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/module/internal/script/js/Assist.kt
@@ -6,9 +6,9 @@ import me.arasple.mc.trmenu.module.internal.data.Metadata
 import me.arasple.mc.trmenu.module.internal.data.NetQuery
 import me.arasple.mc.trmenu.module.internal.hook.HookPlugin
 import me.arasple.mc.trmenu.util.Bungees
+import me.arasple.mc.trmenu.util.ClassUtils
 import me.arasple.mc.trmenu.util.bukkit.Heads
 import me.arasple.mc.trmenu.util.bukkit.ItemMatcher
-import me.arasple.mc.trmenu.util.ClassUtils
 import me.clip.placeholderapi.PlaceholderAPI
 import org.apache.commons.lang3.math.NumberUtils
 import org.bukkit.Bukkit
@@ -26,6 +26,7 @@ import taboolib.module.nms.getItemTag
 import taboolib.platform.compat.getBalance
 import taboolib.platform.util.ItemBuilder
 import taboolib.type.BukkitEquipment
+import java.util.*
 
 
 /**
@@ -37,6 +38,8 @@ class Assist {
     companion object {
 
         val INSTANCE = Assist()
+
+        private val romanNumbers = TreeMap(mapOf(1000 to "M", 900 to "CM", 500 to "D", 400 to "CD", 100 to "C", 90 to "XC", 50 to "L", 40 to "XL", 10 to "X", 9 to "IX", 5 to "V", 4 to "IV", 1 to "I"))
 
     }
 
@@ -270,6 +273,16 @@ class Assist {
         return number.toDoubleOrNull() ?: def
     }
 
+    fun toRoman(number: String): String {
+        return toRoman(toInt(number))
+    }
+
+    fun toRoman(number: Int): String {
+        if (number < 1) return ""
+        val mapNumber = romanNumbers.floorKey(number)
+        return if (mapNumber == number) romanNumbers[number]!! else romanNumbers[mapNumber] + toRoman(number - mapNumber)
+    }
+
     fun isWithin(input: String, low: String, high: String): Boolean {
         return (low.toInt()..high.toInt()).contains(input.toInt())
     }
@@ -317,6 +330,10 @@ class Assist {
 
     fun staticClass(className: String): Any? {
         return ClassUtils.staticClass(className)
+    }
+
+    fun join(separator: String, list: List<Any>): String {
+        return list.joinToString(separator)
     }
 
 

--- a/src/main/kotlin/me/arasple/mc/trmenu/util/bukkit/ItemHelper.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/util/bukkit/ItemHelper.kt
@@ -120,9 +120,9 @@ object ItemHelper {
 
     fun fromPlayerInv(inv: PlayerInventory, item: String): Any? {
         return when (item.lowercase()) {
-            "all" -> inv.contents
+            "all", "inv" -> inv.contents
             "armor" -> inv.armorContents
-            "hand" -> inv.itemInHand
+            "hand", "mainhand" -> inv.itemInHand
             "offhand" -> inv.itemInOffHand
             "helmet" -> inv.armorContents[3]
             "chestplate" -> inv.armorContents[2]


### PR DESCRIPTION
## Changes
* Removed "custom enchant option" from enchant item action.
* Added new utils to Javascript Assist
* Added edit item action
### Edit Item format
`edit-item: method item part value`
**Methods:** set, remove & add
**Item Types:** all, armor, hand, offhand, helmet, chestplate, leggings, boots or inventory index by number.
**Parts:** material, name, lore, flags
* Value is separated by " ", but you can use `` to add values with spaces.
* For lore part you can separate by : to specify certain lore line **index**, for example `lore:2` (third line).
And use "last" for last line index.
## Examples
* `edit-item: set hand name &eColored Name`
* `edit-item: remove helmet flag HIDE_ENCHANTS`
* `edit-item: add offhand lore:0 '&7Line #1' '&7Line #2' '&7Line #3'`