### PR TITLE
Set agent action & new menu open format

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     `maven-publish`
     id("java")
-    id("io.izzel.taboolib") version "1.31"
+    id("io.izzel.taboolib") version "1.33"
     id("org.jetbrains.kotlin.jvm") version "1.6.0"
 }
 
@@ -11,6 +11,7 @@ taboolib {
     install(
         "common",
         "common-5",
+        "expansion-javascript",
         "module-kether",
         "module-ui",
         "module-ui-receptacle",
@@ -44,26 +45,25 @@ taboolib {
     }
 
     classifier = null
-    version = "6.0.6-24"
+    version = "6.0.7-13"
 }
 
 repositories {
     mavenCentral()
+    maven("https://repo.tabooproject.org/repository/releases")
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
     maven("https://repo.codemc.org/repository/maven-public")
 }
 
 dependencies {
     // Libraries
-    compileOnly("org.jetbrains.kotlin:kotlin-stdlib")
+    compileOnly(kotlin("stdlib"))
     compileOnly("org.apache.commons:commons-lang3:3.12.0")
 
     // Server Core
-    compileOnly("ink.ptms.core:v11701:11701:mapped")
-    compileOnly("ink.ptms.core:v11701:11701:universal")
-    compileOnly("ink.ptms.core:v11604:11604:all")
-    compileOnly("ink.ptms.core:v11600:11600:all")
-    compileOnly("ink.ptms.core:v11200:11200:all")
+    compileOnly("ink.ptms.core:v11701:11701-minimize:mapped")
+    compileOnly("ink.ptms.core:v11701:11701-minimize:universal")
+    compileOnly("ink.ptms.core:v11604:11604")
 
     // Hook Plugins
     compileOnly("me.clip:placeholderapi:2.10.9")

--- a/src/main/kotlin/me/arasple/mc/trmenu/api/action/Actions.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/api/action/Actions.kt
@@ -49,6 +49,7 @@ object Actions {
         ActionReloadInventory.registery,
         ActionRefresh.registery,
         ActionUpdate.registery,
+        ActionSetAgent.registery,
         ActionMetaSet.registery,
         ActionMetaDel.registery,
         ActionDataSet.registery,

--- a/src/main/kotlin/me/arasple/mc/trmenu/api/action/impl/ActionSetAgent.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/api/action/impl/ActionSetAgent.kt
@@ -1,0 +1,31 @@
+package me.arasple.mc.trmenu.api.action.impl
+
+import me.arasple.mc.trmenu.api.action.base.AbstractAction
+import me.arasple.mc.trmenu.api.action.base.ActionOption
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+
+/**
+ * @author Rubenicos
+ * @date 2022/1/1 11:40
+ */
+class ActionSetAgent(content: String, option: ActionOption) : AbstractAction(content, option) {
+
+    override fun onExecute(player: Player, placeholderPlayer: Player) {
+        val agent = Bukkit.getPlayerExact(parseContent(placeholderPlayer)) ?: return
+
+        player.session().agent = agent
+    }
+
+    companion object {
+
+        private val name = "(set|change)-?agent".toRegex()
+
+        private val parser: (Any, ActionOption) -> AbstractAction = { value, option ->
+            ActionSetAgent(value.toString(), option)
+        }
+
+        val registery = name to parser
+
+    }
+}

--- a/src/main/kotlin/me/arasple/mc/trmenu/module/display/MenuSession.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/module/display/MenuSession.kt
@@ -11,7 +11,6 @@ import me.arasple.mc.trmenu.util.parseGradients
 import me.arasple.mc.trmenu.util.parseRainbow
 import org.bukkit.entity.Player
 import taboolib.common.platform.service.PlatformExecutor
-import taboolib.module.chat.HexColor
 import taboolib.common.util.replaceWithOrder
 import taboolib.module.chat.colored
 import taboolib.module.configuration.Configuration
@@ -27,7 +26,7 @@ class MenuSession(
     var menu: Menu?,
     var page: Int,
     arguments: Array<String>,
-    private var agent: Player? = null,
+    var agent: Player = viewer,
     var receptacle: Receptacle? = null
 ) {
 
@@ -42,7 +41,7 @@ class MenuSession(
      */
     val placeholderPlayer: Player
         get() {
-            return agent ?: viewer
+            return if (agent.isOnline) agent else viewer
         }
 
     private var mark = System.currentTimeMillis()
@@ -139,7 +138,7 @@ class MenuSession(
         menu?.removeViewer(viewer)
         menu = null
         page = -1
-        agent = null
+        agent = viewer
         receptacle = null
     }
 

--- a/src/main/kotlin/me/arasple/mc/trmenu/module/internal/command/impl/CommandOpen.kt
+++ b/src/main/kotlin/me/arasple/mc/trmenu/module/internal/command/impl/CommandOpen.kt
@@ -5,11 +5,9 @@ import me.arasple.mc.trmenu.api.event.MenuOpenEvent
 import me.arasple.mc.trmenu.module.display.Menu
 import me.arasple.mc.trmenu.module.internal.command.CommandExpresser
 import me.arasple.mc.trmenu.module.internal.data.Metadata
-import me.arasple.mc.trmenu.util.trueOrNull
 import org.bukkit.Bukkit
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
-import taboolib.common.platform.command.CommandContext
 import taboolib.common.platform.command.subCommand
 import taboolib.platform.util.sendLang
 
@@ -54,7 +52,9 @@ object CommandOpen : CommandExpresser {
                     val split = context.argument(-1).split(":")
                     val menu = TrMenuAPI.getMenuById(split[0])
                     val page = split.getOrNull(1)?.toIntOrNull() ?: 0
-                    val player = Bukkit.getPlayerExact(if (argument.contains(" ")) argument.substringBefore(" ") else argument) ?: sender as? Player
+                    val players = (if (argument.contains(" ")) argument.substringBefore(" ") else argument).split(":")
+                    val player = Bukkit.getPlayerExact(players[0]) ?: sender as? Player
+                    val agent = if (players.size > 1) Bukkit.getPlayerExact(players[1]) else null
                     val arguments = runCatching {
                         argument.split(" ").let {
                             it.slice(1 until it.size)
@@ -65,8 +65,12 @@ object CommandOpen : CommandExpresser {
                     if (player == null || !player.isOnline) {
                         return@execute sender.sendLang("Command-Open-Unknown-Player", context.argument(0))
                     }
+                    if (players.size > 1 && (agent == null || !agent.isOnline)) {
+                        return@execute sender.sendLang("Command-Open-Unknown-Player", players[1])
+                    }
 
                     menu.open(player, page, MenuOpenEvent.Reason.PLAYER_COMMAND) {
+                        it.agent = if (agent != null ) agent else player
                         if (!Metadata.byBukkit(player, "FORCE_ARGS") || (arguments.isNotEmpty())) {
                             if (arguments.isEmpty()) {
                                 it.arguments = it.implicitArguments.clone()


### PR DESCRIPTION
## Changes
* Open command format: `/trmenu open <menu> [player][:agent] [args...]`
For example: `/trmenu open example Player1:OtherPlayer` opens "example" menu for Player1 as if it were OtherPlayer
(`:agent` parameter is completely optional)

## Additions
* `set-agent` action to change current menu agent (to view the menu as if you were another online player)
Example: `set-agent: Player2`

## Fixes
* Fix InsinuateProjects#112